### PR TITLE
use slices vs pointers to slices

### DIFF
--- a/db/node.go
+++ b/db/node.go
@@ -11,14 +11,14 @@ import (
 func (o *OsmDB) GetNode(id int64) (*osm.Node, error) {
 	nodeQuery := fmt.Sprintf(`
 SELECT
-	id, 
-	visible, 
-	version, 
-	lat, 
-	lon, 
-	changeset, 
+	id,
+	visible,
+	version,
+	lat,
+	lon,
+	changeset,
 	"user",
-	uid, 
+	uid,
 	timestamp,
 	COALESCE(to_json(tags), '[]') AS tags
 FROM get_node_by_id(%v)`, id)
@@ -59,7 +59,7 @@ SELECT
 	id,
 	visible,
 	version,
-	lat, 
+	lat,
 	lon,
 	changeset,
 	"user",
@@ -98,17 +98,17 @@ FROM get_node_by_id_and_version(array[[%v, %v]])`, id, version)
 }
 
 // GetNodeHistory selects node history from database by id
-func (o *OsmDB) GetNodeHistory(id int64) (*osm.Nodes, error) {
+func (o *OsmDB) GetNodeHistory(id int64) (osm.Nodes, error) {
 	query := fmt.Sprintf(`
 	SELECT
-		id, 
-		visible, 
-		version, 
-		lat, 
-		lon, 
-		changeset, 
+		id,
+		visible,
+		version,
+		lat,
+		lon,
+		changeset,
 		"user",
-		uid, 
+		uid,
 		timestamp,
 		COALESCE(to_json(tags), '[]') AS tags
 	FROM get_node_history_by_id(%v)
@@ -120,7 +120,7 @@ func (o *OsmDB) GetNodeHistory(id int64) (*osm.Nodes, error) {
 	}
 	defer rows.Close()
 
-	nodes := &osm.Nodes{}
+	var nodes osm.Nodes
 	for rows.Next() {
 		var user sql.NullString
 		var userID sql.NullInt64
@@ -148,14 +148,14 @@ func (o *OsmDB) GetNodeHistory(id int64) (*osm.Nodes, error) {
 			}
 		}
 
-		*nodes = append(*nodes, node)
+		nodes = append(nodes, node)
 	}
 
 	return nodes, nil
 }
 
 // GetNodes selects nodes from database by ids
-func (o *OsmDB) GetNodes(ids []int64, idvs [][2]int64) (*osm.Nodes, error) {
+func (o *OsmDB) GetNodes(ids []int64, idvs [][2]int64) (osm.Nodes, error) {
 	if len(ids) == 0 &&
 		len(idvs) == 0 {
 		return nil, nil
@@ -204,7 +204,7 @@ func (o *OsmDB) GetNodes(ids []int64, idvs [][2]int64) (*osm.Nodes, error) {
 	}
 	defer rows.Close()
 
-	nodes := &osm.Nodes{}
+	var nodes osm.Nodes
 	for rows.Next() {
 		var user sql.NullString
 		var userID sql.NullInt64
@@ -232,7 +232,7 @@ func (o *OsmDB) GetNodes(ids []int64, idvs [][2]int64) (*osm.Nodes, error) {
 			}
 		}
 
-		*nodes = append(*nodes, node)
+		nodes = append(nodes, node)
 	}
 
 	return nodes, nil

--- a/db/relation.go
+++ b/db/relation.go
@@ -11,9 +11,9 @@ import (
 func (o *OsmDB) GetRelation(id int64) (*osm.Relation, error) {
 	relationQuery := fmt.Sprintf(`
 	SELECT
-		id, 
-		visible, 
-		version,  
+		id,
+		visible,
+		version,
 		"user",
 		uid,
 		changeset,
@@ -54,9 +54,9 @@ func (o *OsmDB) GetRelation(id int64) (*osm.Relation, error) {
 func (o *OsmDB) GetRelationByVersion(id, version int64) (*osm.Relation, error) {
 	relationQuery := fmt.Sprintf(`
 	SELECT
-		id, 
-		visible, 
-		version,  
+		id,
+		visible,
+		version,
 		"user",
 		uid,
 		changeset,
@@ -133,7 +133,7 @@ func (o *OsmDB) GetRelationFull(id int64) (*osm.OSM, error) {
 		SELECT array_to_json(array_agg(n)) AS nodes FROM nodes n
 	)
 	SELECT COALESCE(r.relations, '[]'), COALESCE(w.ways, '[]'), COALESCE(n.nodes, '[]')
-	FROM relations_array r, ways_array w, nodes_array n	
+	FROM relations_array r, ways_array w, nodes_array n
 	`, id)
 
 	osm := osm.New()
@@ -146,12 +146,12 @@ func (o *OsmDB) GetRelationFull(id int64) (*osm.OSM, error) {
 }
 
 // GetRelationHistory selects relation history from databASe by id
-func (o *OsmDB) GetRelationHistory(id int64) (*osm.Relations, error) {
+func (o *OsmDB) GetRelationHistory(id int64) (osm.Relations, error) {
 	query := fmt.Sprintf(`
 	SELECT
-		id, 
-		visible, 
-		version,  
+		id,
+		visible,
+		version,
 		"user",
 		uid,
 		changeset,
@@ -166,7 +166,7 @@ func (o *OsmDB) GetRelationHistory(id int64) (*osm.Relations, error) {
 	}
 	defer rows.Close()
 
-	relations := &osm.Relations{}
+	var relations osm.Relations
 	for rows.Next() {
 		var user sql.NullString
 		var userID sql.NullInt64
@@ -193,14 +193,14 @@ func (o *OsmDB) GetRelationHistory(id int64) (*osm.Relations, error) {
 			}
 		}
 
-		*relations = append(*relations, relation)
+		relations = append(relations, relation)
 	}
 
 	return relations, nil
 }
 
 // GetRelations returns relations by ids
-func (o *OsmDB) GetRelations(ids []int64, idvs [][2]int64) (*osm.Relations, error) {
+func (o *OsmDB) GetRelations(ids []int64, idvs [][2]int64) (osm.Relations, error) {
 	if len(ids) == 0 &&
 		len(idvs) == 0 {
 		return nil, nil
@@ -210,9 +210,9 @@ func (o *OsmDB) GetRelations(ids []int64, idvs [][2]int64) (*osm.Relations, erro
 	if len(ids) > 0 {
 		query = fmt.Sprintf(`
 		SELECT
-			id, 
-			visible, 
-			version,  
+			id,
+			visible,
+			version,
 			"user",
 			uid,
 			changeset,
@@ -228,9 +228,9 @@ func (o *OsmDB) GetRelations(ids []int64, idvs [][2]int64) (*osm.Relations, erro
 		}
 		query += fmt.Sprintf(`
 		SELECT
-			id, 
-			visible, 
-			version,  
+			id,
+			visible,
+			version,
 			"user",
 			uid,
 			changeset,
@@ -247,7 +247,7 @@ func (o *OsmDB) GetRelations(ids []int64, idvs [][2]int64) (*osm.Relations, erro
 	}
 	defer rows.Close()
 
-	relations := &osm.Relations{}
+	var relations osm.Relations
 	for rows.Next() {
 		var user sql.NullString
 		var userID sql.NullInt64
@@ -274,7 +274,7 @@ func (o *OsmDB) GetRelations(ids []int64, idvs [][2]int64) (*osm.Relations, erro
 			}
 		}
 
-		*relations = append(*relations, relation)
+		relations = append(relations, relation)
 	}
 
 	return relations, nil

--- a/db/way.go
+++ b/db/way.go
@@ -11,12 +11,12 @@ import (
 func (o *OsmDB) GetWay(id int64) (*osm.Way, error) {
 	wayQuery := fmt.Sprintf(`
 	SELECT
-		id, 
-		visible, 
+		id,
+		visible,
 		version,
 		"user",
 		uid,
-		changeset, 
+		changeset,
 		timestamp,
 		COALESCE(to_json(nodes), '[]') AS nodes,
 		COALESCE(to_json(tags), '[]') AS tags
@@ -55,12 +55,12 @@ func (o *OsmDB) GetWay(id int64) (*osm.Way, error) {
 func (o *OsmDB) GetWayByVersion(id, version int64) (*osm.Way, error) {
 	wayQuery := fmt.Sprintf(`
 	SELECT
-		id, 
-		visible, 
+		id,
+		visible,
 		version,
 		"user",
 		uid,
-		changeset, 
+		changeset,
 		timestamp,
 		COALESCE(to_json(nodes), '[]') AS nodes,
 		COALESCE(to_json(tags), '[]') AS tags
@@ -126,15 +126,15 @@ func (o *OsmDB) GetWayFull(id int64) (*osm.OSM, error) {
 }
 
 // GetWayHistory selects way history from database by id
-func (o *OsmDB) GetWayHistory(id int64) (*osm.Ways, error) {
+func (o *OsmDB) GetWayHistory(id int64) (osm.Ways, error) {
 	query := fmt.Sprintf(`
 	SELECT
-		id, 
-		visible, 
+		id,
+		visible,
 		version,
 		"user",
 		uid,
-		changeset, 
+		changeset,
 		timestamp,
 		COALESCE(to_json(nodes), '[]') AS nodes,
 		COALESCE(to_json(tags), '[]') AS tags
@@ -147,7 +147,7 @@ func (o *OsmDB) GetWayHistory(id int64) (*osm.Ways, error) {
 	}
 	defer rows.Close()
 
-	ways := &osm.Ways{}
+	var ways osm.Ways
 	for rows.Next() {
 		var user sql.NullString
 		var userID sql.NullInt64
@@ -174,14 +174,14 @@ func (o *OsmDB) GetWayHistory(id int64) (*osm.Ways, error) {
 			}
 		}
 
-		*ways = append(*ways, way)
+		ways = append(ways, way)
 	}
 
 	return ways, nil
 }
 
 // GetWays returns ways by ids
-func (o *OsmDB) GetWays(ids []int64, idvs [][2]int64) (*osm.Ways, error) {
+func (o *OsmDB) GetWays(ids []int64, idvs [][2]int64) (osm.Ways, error) {
 	if len(ids) == 0 &&
 		len(idvs) == 0 {
 		return nil, nil
@@ -191,12 +191,12 @@ func (o *OsmDB) GetWays(ids []int64, idvs [][2]int64) (*osm.Ways, error) {
 	if len(ids) > 0 {
 		query = fmt.Sprintf(`
 		SELECT
-			id, 
-			visible, 
+			id,
+			visible,
 			version,
 			"user",
 			uid,
-			changeset, 
+			changeset,
 			timestamp,
 			COALESCE(to_jsonb(nodes), '[]') AS nodes,
 			COALESCE(to_jsonb(tags), '[]') AS tags
@@ -209,12 +209,12 @@ func (o *OsmDB) GetWays(ids []int64, idvs [][2]int64) (*osm.Ways, error) {
 		}
 		query += fmt.Sprintf(`
 		SELECT
-			id, 
-			visible, 
+			id,
+			visible,
 			version,
 			"user",
 			uid,
-			changeset, 
+			changeset,
 			timestamp,
 			COALESCE(to_jsonb(nodes), '[]') AS nodes,
 			COALESCE(to_jsonb(tags), '[]') AS tags
@@ -228,7 +228,7 @@ func (o *OsmDB) GetWays(ids []int64, idvs [][2]int64) (*osm.Ways, error) {
 	}
 	defer rows.Close()
 
-	ways := &osm.Ways{}
+	var ways osm.Ways
 	for rows.Next() {
 		var user sql.NullString
 		var userID sql.NullInt64
@@ -255,7 +255,7 @@ func (o *OsmDB) GetWays(ids []int64, idvs [][2]int64) (*osm.Ways, error) {
 			}
 		}
 
-		*ways = append(*ways, way)
+		ways = append(ways, way)
 	}
 
 	return ways, nil

--- a/server/node.go
+++ b/server/node.go
@@ -79,7 +79,7 @@ func (s *Server) GetNodeHistory(c echo.Context) error {
 	}
 
 	resp := osm.New()
-	resp.Nodes = *nodes
+	resp.Nodes = nodes
 
 	s.SetHeaders(c)
 	return xml.NewEncoder(c.Response()).Encode(resp)
@@ -120,13 +120,13 @@ func (s *Server) GetNodes(c echo.Context) error {
 		return err
 	}
 
-	if len(*nodes) != len(cIDs)+len(nIDsVs) {
+	if len(nodes) != len(cIDs)+len(nIDsVs) {
 		s.SetEmptyResultHeaders(c, http.StatusNotFound)
 		return nil
 	}
 
 	resp := osm.New()
-	for _, node := range *nodes {
+	for _, node := range nodes {
 		if !node.Visible {
 			node.Lat = nil
 			node.Lon = nil

--- a/server/relation.go
+++ b/server/relation.go
@@ -96,7 +96,7 @@ func (s *Server) GetRelationHistory(c echo.Context) error {
 	}
 
 	resp := osm.New()
-	resp.Relations = *relations
+	resp.Relations = relations
 
 	s.SetHeaders(c)
 	return xml.NewEncoder(c.Response()).Encode(resp)
@@ -137,13 +137,13 @@ func (s *Server) GetRelations(c echo.Context) error {
 		return err
 	}
 
-	if len(*relations) != len(cIDs)+len(nIDsVs) {
+	if len(relations) != len(cIDs)+len(nIDsVs) {
 		s.SetEmptyResultHeaders(c, http.StatusNotFound)
 		return nil
 	}
 
 	resp := osm.New()
-	resp.Relations = *relations
+	resp.Relations = relations
 
 	s.SetHeaders(c)
 	return xml.NewEncoder(c.Response()).Encode(resp)

--- a/server/way.go
+++ b/server/way.go
@@ -101,7 +101,7 @@ func (s *Server) GetWayHistory(c echo.Context) error {
 	}
 
 	resp := osm.New()
-	resp.Ways = *ways
+	resp.Ways = ways
 
 	s.SetHeaders(c)
 	return xml.NewEncoder(c.Response()).Encode(resp)
@@ -142,13 +142,13 @@ func (s *Server) GetWays(c echo.Context) error {
 		return err
 	}
 
-	if len(*ways) != len(cIDs)+len(nIDsVs) {
+	if len(ways) != len(cIDs)+len(nIDsVs) {
 		s.SetEmptyResultHeaders(c, http.StatusNotFound)
 		return nil
 	}
 
 	resp := osm.New()
-	resp.Ways = *ways
+	resp.Ways = ways
 
 	s.SetHeaders(c)
 	return xml.NewEncoder(c.Response()).Encode(resp)


### PR DESCRIPTION
slices in go are weird. they are basically *pointer* to a sliceHeader, so there is no need for another header. For example:
```
var s []int
s == nil
len(s) == 0 
```
actually allocate the header
```
s := []int{}
s != nil 
len(s) == 0
```

The former will jsonify to `null` the latter will jsonify to `[]` but they will both be excluded by `omitempty` . That may start to matter when you provide results in json. https://play.golang.org/p/EGl1hcJg9E9

also removed some trailing whitespace.