### PR TITLE
time marshals to iso8601 utc

### DIFF
--- a/osm/helpers.go
+++ b/osm/helpers.go
@@ -7,7 +7,7 @@ import (
 	"time"
 )
 
-const osmTimeFormat = "2006-01-02T15:04:05"
+const osmTimeFormat = "2006-01-02T15:04:05Z"
 
 // Tag represents osm tag
 type Tag struct {
@@ -27,7 +27,7 @@ func (ts *Tags) Scan(value interface{}) error {
 type TimeOSM time.Time
 
 func (t *TimeOSM) String() string {
-	return time.Time(*t).Format(osmTimeFormat)
+	return time.Time(*t).UTC().Format(osmTimeFormat)
 }
 
 // Scan - Implement the database/sql scanner interface

--- a/osm/helpers_test.go
+++ b/osm/helpers_test.go
@@ -1,0 +1,39 @@
+package osm
+
+import (
+	"testing"
+	"time"
+)
+
+func TestTimeOSMString(t *testing.T) {
+	newYork, err := time.LoadLocation("America/New_York")
+	if err != nil {
+		t.Fatalf("invalid timezone: %v", err)
+	}
+
+	cases := []struct {
+		name     string
+		time     time.Time
+		expected string
+	}{
+		{
+			name:     "iso 8601 format",
+			time:     time.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC),
+			expected: "2012-01-01T00:00:00Z",
+		},
+		{
+			name:     "always UTC",
+			time:     time.Date(2012, 1, 1, 0, 0, 0, 0, newYork),
+			expected: "2012-01-01T05:00:00Z",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tosm := TimeOSM(tc.time)
+			if v := tosm.String(); v != tc.expected {
+				t.Errorf("incorrect format: %v", v)
+			}
+		})
+	}
+}


### PR DESCRIPTION
fixes https://github.com/osmlab/yalcha/issues/11 

One suggestion is to rename this type to just `Time` since it's in the `osm` package already. Externally it would be referred to as `osm.Time` which is pretty.

